### PR TITLE
Close #70: Broadcast transaction using CLI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,8 +9,9 @@ pipeline:
     image: gcr.io/time-coin/sbt:latest
     volumes:
       - /var/lib/sbt-cache:/workdir/sbt
-      - /var/lib/ivy-cache:/workdir/ivy
+      - /var/lib/coursier-cache:/workdir/coursier
     commands:
+      - export COURSIER_CACHE='/workdir/coursier/'
       - export SBT_OPTS='-Dsbt.global.base=/workdir/sbt/ -Dsbt.ivy.home=/workdir/ivy/ -Divy.home=/workdir/ivy/'
       - git clone https://github.com/mytimecoin/scala-abci-server.git scala-abci-server --depth 1
       - cd /workdir/code/scala-abci-server && sbt $SBT_OPTS publishLocal
@@ -19,13 +20,14 @@ pipeline:
     image: gcr.io/time-coin/sbt:latest
     volumes:
       - /var/lib/sbt-cache:/workdir/sbt
-      - /var/lib/ivy-cache:/workdir/ivy
+      - /var/lib/coursier-cache:/workdir/coursier
     commands:
-      - export SBT_OPTS='-Dsbt.global.base=/workdir/sbt/ -Dsbt.ivy.home=/workdir/ivy/ -Divy.home=/workdir/ivy/'
+      - export SBT_OPTS='-Dsbt.global.base=/workdir/sbt/'
+      - export COURSIER_CACHE='/workdir/coursier/'
       - cd /workdir/code && sbt $SBT_OPTS -mem 2048 cli/universal:packageBin
     when:
       event: tag
-  github_release:
+  release:
     image: plugins/github-release
     files:
       - /workdir/code/cli/target/universal/*.zip

--- a/cli/src/main/scala/pravda/cli/Application.scala
+++ b/cli/src/main/scala/pravda/cli/Application.scala
@@ -30,14 +30,15 @@ object Application extends App {
   lazy val runner = new RunBytecode(io, vm)
   lazy val broadcast = new Broadcast(io, api, compilers)
 
-  val eventuallyExitCode = Parser.parse(args, Config.Nope) match {
+  // FIXME programs should be composed by another one
+  val eventuallyExitCode = ArgumentsParser.parse(args, Config.Nope) match {
     case Some(config: Config.Compile)     => compile(config).map(_ => 0)
     case Some(config: Config.RunBytecode) => runner(config).map(_ => 0)
     case Some(config: Config.GenAddress)  => genAddress(config).map(_ => 0)
     case Some(config: Config.Broadcast)   => broadcast(config).map(_ => 0)
     case _ =>
       Future {
-        stderr.println(Parser.renderTwoColumnsUsage)
+        stderr.println(ArgumentsParser.renderTwoColumnsUsage)
         1 // every non zero exit code says about error
       }
   }

--- a/cli/src/main/scala/pravda/cli/Application.scala
+++ b/cli/src/main/scala/pravda/cli/Application.scala
@@ -9,6 +9,7 @@ import sys.process.stderr
   */
 object Application extends App {
 
+  lazy val api = new NodeApiLanguageImpl()
   lazy val io = new IoLanguageImpl()
   lazy val compilers = new CompilersLanguageImpl()
   lazy val random = new RandomLanguageImpl()
@@ -17,11 +18,13 @@ object Application extends App {
   lazy val compile = new Compile(io, compilers)
   lazy val genAddress = new GenAddress(io, random)
   lazy val runner = new RunBytecode(io, vm)
+  lazy val broadcast = new Broadcast(io, api, compilers)
 
   Parser.parse(args, Config.Nope) match {
     case Some(config: Config.Compile)     => compile(config)
     case Some(config: Config.RunBytecode) => runner(config)
     case Some(config: Config.GenAddress)  => genAddress(config)
+    case Some(config: Config.Broadcast)   => broadcast(config)
     case _ =>
       stderr.println(Parser.renderTwoColumnsUsage)
       sys.exit(1)

--- a/cli/src/main/scala/pravda/cli/Application.scala
+++ b/cli/src/main/scala/pravda/cli/Application.scala
@@ -1,13 +1,23 @@
 package pravda.cli
 
+import cats.implicits._
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import pravda.cli.languages.impl._
 import pravda.cli.programs._
+
+import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 import sys.process.stderr
+import scala.concurrent.duration._
 
 /**
   * Pravda CLI entry point.
   */
 object Application extends App {
+
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
   lazy val api = new NodeApiLanguageImpl()
   lazy val io = new IoLanguageImpl()
@@ -20,14 +30,23 @@ object Application extends App {
   lazy val runner = new RunBytecode(io, vm)
   lazy val broadcast = new Broadcast(io, api, compilers)
 
-  Parser.parse(args, Config.Nope) match {
-    case Some(config: Config.Compile)     => compile(config)
-    case Some(config: Config.RunBytecode) => runner(config)
-    case Some(config: Config.GenAddress)  => genAddress(config)
-    case Some(config: Config.Broadcast)   => broadcast(config)
+  val eventuallyExitCode = Parser.parse(args, Config.Nope) match {
+    case Some(config: Config.Compile)     => compile(config).map(_ => 0)
+    case Some(config: Config.RunBytecode) => runner(config).map(_ => 0)
+    case Some(config: Config.GenAddress)  => genAddress(config).map(_ => 0)
+    case Some(config: Config.Broadcast)   => broadcast(config).map(_ => 0)
     case _ =>
-      stderr.println(Parser.renderTwoColumnsUsage)
-      sys.exit(1)
+      Future {
+        stderr.println(Parser.renderTwoColumnsUsage)
+        1 // every non zero exit code says about error
+      }
   }
 
+  // FIXME handle exceptions
+  val exitCode = Await.result(
+    awaitable = for (exitCode <- eventuallyExitCode; _ <- system.terminate()) yield exitCode,
+    atMost = 1.day // should be enough :)
+  )
+
+  sys.exit(exitCode)
 }

--- a/cli/src/main/scala/pravda/cli/ArgumentsParser.scala
+++ b/cli/src/main/scala/pravda/cli/ArgumentsParser.scala
@@ -6,7 +6,7 @@ import pravda.cli.Config.CompileMode
 import pravda.common.bytes
 import scopt.OptionParser
 
-object Parser extends OptionParser[Config]("pravda") {
+object ArgumentsParser extends OptionParser[Config]("pravda") {
 
   head("Pravda Command Line Interface")
 
@@ -151,8 +151,8 @@ object Parser extends OptionParser[Config]("pravda") {
       opt[String]('e', "endpoint")
         .text("Node endpoint (http://localhost:8080/api/public/broadcast by default).")
         .action {
-          case (endpoint, config: Config.Compile) =>
-            config.copy(input = Some(endpoint))
+          case (endpoint, config: Config.Broadcast) =>
+            config.copy(endpoint = endpoint)
           case (_, otherwise) => otherwise
         },
     )

--- a/cli/src/main/scala/pravda/cli/Config.scala
+++ b/cli/src/main/scala/pravda/cli/Config.scala
@@ -6,21 +6,39 @@ object Config {
 
   final val DefaultExecutor = "e74b91ee9dda326116a08703eb387cc27a47e5d832072346fd65c40b89629b86"
 
-  sealed trait PravdaCompile
+  sealed trait CompileMode
 
-  object PravdaCompile {
-    case object Nope   extends PravdaCompile
-    case object Asm    extends PravdaCompile
-    case object Disasm extends PravdaCompile
-    case object Forth  extends PravdaCompile
-    case object DotNet extends PravdaCompile
+  object CompileMode {
+    case object Nope   extends CompileMode
+    case object Asm    extends CompileMode
+    case object Disasm extends CompileMode
+    case object Forth  extends CompileMode
+    case object DotNet extends CompileMode
   }
 
   case object Nope extends Config
 
   final case class GenAddress(output: Option[String] = None) extends Config
 
-  final case class Compile(compiler: PravdaCompile, input: Option[String] = None, output: Option[String] = None)
+  final case class Broadcast(mode: Broadcast.Mode = Broadcast.Mode.Nope,
+                             wallet: Option[String] = None,
+                             input: Option[String] = None,
+                             endpoint: String = "http://localhost:8080/api/public/broadcast")
+      extends Config
+
+  object Broadcast {
+
+    sealed trait Mode
+
+    object Mode {
+      case object Nope                                 extends Mode
+      case object Deploy                               extends Mode
+      case object Run                                  extends Mode
+      final case class Update(program: Option[String]) extends Mode
+    }
+  }
+
+  final case class Compile(compiler: CompileMode, input: Option[String] = None, output: Option[String] = None)
       extends Config
 
   final case class RunBytecode(storage: Option[String] = None,

--- a/cli/src/main/scala/pravda/cli/Parser.scala
+++ b/cli/src/main/scala/pravda/cli/Parser.scala
@@ -2,7 +2,7 @@ package pravda.cli
 
 import java.io.File
 
-import pravda.cli.Config.PravdaCompile
+import pravda.cli.Config.CompileMode
 import pravda.common.bytes
 import scopt.OptionParser
 
@@ -59,7 +59,7 @@ object Parser extends OptionParser[Config]("pravda") {
     )
 
   cmd("compile")
-    .action((_, _) => Config.Compile(PravdaCompile.Nope))
+    .action((_, _) => Config.Compile(CompileMode.Nope))
     .children(
       opt[File]('i', "input")
         .text("Input file")
@@ -79,28 +79,80 @@ object Parser extends OptionParser[Config]("pravda") {
         .text("Assemble Pravda VM bytecode from text presentation.")
         .action {
           case (_, config: Config.Compile) =>
-            config.copy(compiler = Config.PravdaCompile.Asm)
+            config.copy(compiler = Config.CompileMode.Asm)
           case (_, otherwise) => otherwise
         },
       cmd("disasm")
         .text("Disassemble Pravda VM bytecode to text presentation.")
         .action {
           case (_, config: Config.Compile) =>
-            config.copy(compiler = Config.PravdaCompile.Disasm)
+            config.copy(compiler = Config.CompileMode.Disasm)
           case (_, otherwise) => otherwise
         },
       cmd("forth")
         .text("Compile Pravda pseudo-forth to Pravda VM bytecode.")
         .action {
           case (_, config: Config.Compile) =>
-            config.copy(compiler = Config.PravdaCompile.Forth)
+            config.copy(compiler = Config.CompileMode.Forth)
           case (_, otherwise) => otherwise
         },
       cmd("dotnet")
         .text("Compile .exe produced byt .NET compiler to Pravda VM bytecode.")
         .action {
           case (_, config: Config.Compile) =>
-            config.copy(compiler = Config.PravdaCompile.DotNet)
+            config.copy(compiler = Config.CompileMode.DotNet)
+          case (_, otherwise) => otherwise
+        },
+    )
+
+  cmd("broadcast")
+    .text("Broadcasting program to the network")
+    .children(
+      cmd("run")
+        .action((_, _) => Config.Broadcast(Config.Broadcast.Mode.Run))
+        .text("")
+        .action {
+          case (_, config: Config.Broadcast) =>
+            config.copy(mode = Config.Broadcast.Mode.Run)
+          case (_, otherwise) => otherwise
+        },
+      cmd("deploy")
+        .text("")
+        .action((_, _) => Config.Broadcast(Config.Broadcast.Mode.Deploy))
+        .action {
+          case (_, config: Config.Broadcast) =>
+            config.copy(mode = Config.Broadcast.Mode.Deploy)
+          case (_, otherwise) => otherwise
+        },
+      cmd("update")
+        .text("")
+        .action((_, _) => Config.Broadcast(Config.Broadcast.Mode.Update(None)))
+        .children(
+          opt[String]('p', "program")
+            .action {
+              case (hex, config: Config.Broadcast) =>
+                config.copy(mode = Config.Broadcast.Mode.Update(Some(hex)))
+              case (_, otherwise) => otherwise
+            }
+        ),
+      opt[File]('i', "input")
+        .text("Input file.")
+        .action {
+          case (file, config: Config.Broadcast) =>
+            config.copy(input = Some(file.getAbsolutePath))
+          case (_, otherwise) => otherwise
+        },
+      opt[File]('w', "wallet")
+        .action {
+          case (file, config: Config.Broadcast) =>
+            config.copy(wallet = Some(file.getAbsolutePath))
+          case (_, otherwise) => otherwise
+        },
+      opt[String]('e', "endpoint")
+        .text("Node endpoint (http://localhost:8080/api/public/broadcast by default).")
+        .action {
+          case (endpoint, config: Config.Compile) =>
+            config.copy(input = Some(endpoint))
           case (_, otherwise) => otherwise
         },
     )

--- a/cli/src/main/scala/pravda/cli/languages/NodeApiLanguage.scala
+++ b/cli/src/main/scala/pravda/cli/languages/NodeApiLanguage.scala
@@ -1,0 +1,13 @@
+package pravda.cli.languages
+
+import com.google.protobuf.ByteString
+
+import scala.language.higherKinds
+
+trait NodeApiLanguage[F[_]] {
+
+  def singAndBroadcastTransaction(uriPrefix: String,
+                                  address: ByteString,
+                                  privateKey: ByteString,
+                                  data: ByteString): F[Either[String, String]]
+}

--- a/cli/src/main/scala/pravda/cli/languages/impl/CompilersLanguageImpl.scala
+++ b/cli/src/main/scala/pravda/cli/languages/impl/CompilersLanguageImpl.scala
@@ -2,24 +2,28 @@ package pravda.cli.languages
 
 package impl
 
-import cats.Id
 import com.google.protobuf.ByteString
 import pravda.forth.{Compiler => ForthCompiler}
 import pravda.vm.asm.Assembler
 
-final class CompilersLanguageImpl extends CompilersLanguage[Id] {
+import scala.concurrent.{ExecutionContext, Future}
 
-  def asm(source: String): Id[Either[String, ByteString]] =
+final class CompilersLanguageImpl(implicit executionContext: ExecutionContext) extends CompilersLanguage[Future] {
+
+  def asm(source: String): Future[Either[String, ByteString]] = Future {
     Assembler()
       .compile(source)
       .map(a => ByteString.copyFrom(a))
+  }
 
-  def disasm(source: ByteString): Id[String] =
+  def disasm(source: ByteString): Future[String] = Future {
     Assembler()
       .decompile(source)
       .map { case (no, op) => "%06X:\t%s".format(no, op.toAsm) }
       .mkString("\n")
+  }
 
-  def forth(source: String): Id[Either[String, ByteString]] =
+  def forth(source: String): Future[Either[String, ByteString]] = Future {
     ForthCompiler().compileToByteString(source)
+  }
 }

--- a/cli/src/main/scala/pravda/cli/languages/impl/NodeApiLanguageImpl.scala
+++ b/cli/src/main/scala/pravda/cli/languages/impl/NodeApiLanguageImpl.scala
@@ -4,7 +4,8 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpEntity, HttpMethods, HttpRequest}
 import akka.stream.ActorMaterializer
-import cats.Id
+import akka.util.{ByteString => AkkaByteString}
+
 import com.google.protobuf.ByteString
 import pravda.cli.languages.NodeApiLanguage
 import pravda.common.bytes
@@ -14,22 +15,18 @@ import pravda.node.data.common.{Address, Mytc}
 import pravda.node.data.cryptography
 import pravda.node.data.cryptography.PrivateKey
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.Random
-import akka.util.{ByteString => AkkaByteString}
-import scala.concurrent.ExecutionContextExecutor
 
-final class NodeApiLanguageImpl extends NodeApiLanguage[Id] {
-
-  private implicit val system: ActorSystem = ActorSystem()
-  private implicit val materializer: ActorMaterializer = ActorMaterializer()
-  private implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+final class NodeApiLanguageImpl(implicit system: ActorSystem,
+                                materializer: ActorMaterializer,
+                                executionContext: ExecutionContextExecutor)
+    extends NodeApiLanguage[Future] {
 
   def singAndBroadcastTransaction(uriPrefix: String,
                                   address: ByteString,
                                   privateKey: ByteString,
-                                  data: ByteString): Id[Either[String, String]] = {
+                                  data: ByteString): Future[Either[String, String]] = {
 
     val tx = UnsignedTransaction(
       from = Address @@ address,
@@ -37,24 +34,23 @@ final class NodeApiLanguageImpl extends NodeApiLanguage[Id] {
       Mytc.zero,
       nonce = Random.nextInt()
     )
+
     val stx = cryptography.signTransaction(PrivateKey @@ privateKey, tx)
     val fromHex = bytes.byteString2hex(address)
     val signatureHex = bytes.byteString2hex(stx.signature)
 
     val request = HttpRequest(
       method = HttpMethods.POST,
-      uri = s"$uriPrefix?from=$fromHex&signature=$signatureHex&fee=0.00",
+      uri = s"$uriPrefix?from=$fromHex&signature=$signatureHex&nonce=${tx.nonce}&fee=0",
       entity = HttpEntity(data.toByteArray)
     )
 
-    val future = Http()
+    Http()
       .singleRequest(request)
       .flatMap { response =>
         response.entity.dataBytes
           .runFold(AkkaByteString(""))(_ ++ _)
-          .map(_.utf8String)
+          .map(x => Right(x.utf8String))
       }
-    // FIXME fomkin: This why we should use Task/Future instead of Id
-    Right(Await.result(future, 10.seconds))
   }
 }

--- a/cli/src/main/scala/pravda/cli/languages/impl/NodeApiLanguageImpl.scala
+++ b/cli/src/main/scala/pravda/cli/languages/impl/NodeApiLanguageImpl.scala
@@ -1,0 +1,60 @@
+package pravda.cli.languages.impl
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpEntity, HttpMethods, HttpRequest}
+import akka.stream.ActorMaterializer
+import cats.Id
+import com.google.protobuf.ByteString
+import pravda.cli.languages.NodeApiLanguage
+import pravda.common.bytes
+import pravda.node.data.blockchain.Transaction.UnsignedTransaction
+import pravda.node.data.blockchain.TransactionData
+import pravda.node.data.common.{Address, Mytc}
+import pravda.node.data.cryptography
+import pravda.node.data.cryptography.PrivateKey
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.Random
+import akka.util.{ByteString => AkkaByteString}
+import scala.concurrent.ExecutionContextExecutor
+
+final class NodeApiLanguageImpl extends NodeApiLanguage[Id] {
+
+  private implicit val system: ActorSystem = ActorSystem()
+  private implicit val materializer: ActorMaterializer = ActorMaterializer()
+  private implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+
+  def singAndBroadcastTransaction(uriPrefix: String,
+                                  address: ByteString,
+                                  privateKey: ByteString,
+                                  data: ByteString): Id[Either[String, String]] = {
+
+    val tx = UnsignedTransaction(
+      from = Address @@ address,
+      program = TransactionData @@ data,
+      Mytc.zero,
+      nonce = Random.nextInt()
+    )
+    val stx = cryptography.signTransaction(PrivateKey @@ privateKey, tx)
+    val fromHex = bytes.byteString2hex(address)
+    val signatureHex = bytes.byteString2hex(stx.signature)
+
+    val request = HttpRequest(
+      method = HttpMethods.POST,
+      uri = s"$uriPrefix?from=$fromHex&signature=$signatureHex&fee=0.00",
+      entity = HttpEntity(data.toByteArray)
+    )
+
+    val future = Http()
+      .singleRequest(request)
+      .flatMap { response =>
+        response.entity.dataBytes
+          .runFold(AkkaByteString(""))(_ ++ _)
+          .map(_.utf8String)
+      }
+    // FIXME fomkin: This why we should use Task/Future instead of Id
+    Right(Await.result(future, 10.seconds))
+  }
+}

--- a/cli/src/main/scala/pravda/cli/languages/impl/RandomLanguageImpl.scala
+++ b/cli/src/main/scala/pravda/cli/languages/impl/RandomLanguageImpl.scala
@@ -4,14 +4,15 @@ package impl
 
 import java.security.SecureRandom
 
-import cats.Id
 import com.google.protobuf.ByteString
 
-final class RandomLanguageImpl extends RandomLanguage[Id] {
+import scala.concurrent.Future
+
+final class RandomLanguageImpl extends RandomLanguage[Future] {
 
   private val secureRandom = new SecureRandom()
 
-  def secureBytes64(): Id[ByteString] = {
+  def secureBytes64(): Future[ByteString] = Future.successful {
     val bytes = new Array[Byte](64)
     secureRandom.nextBytes(bytes)
     ByteString.copyFrom(bytes)

--- a/cli/src/main/scala/pravda/cli/languages/impl/VmLanguageImpl.scala
+++ b/cli/src/main/scala/pravda/cli/languages/impl/VmLanguageImpl.scala
@@ -2,7 +2,6 @@ package pravda.cli.languages
 
 package impl
 
-import cats.Id
 import com.google.protobuf.ByteString
 import pravda.node.data.common.TransactionId
 import pravda.node.db.DB
@@ -10,9 +9,11 @@ import pravda.node.servers
 import pravda.vm.Vm
 import pravda.vm.state.{Memory, VmErrorException}
 
-final class VmLanguageImpl extends VmLanguage[Id] {
+import scala.concurrent.{ExecutionContext, Future}
 
-  def run(program: ByteString, executor: ByteString, storagePath: String): Id[Either[String, Memory]] = {
+final class VmLanguageImpl(implicit executionContext: ExecutionContext) extends VmLanguage[Future] {
+
+  def run(program: ByteString, executor: ByteString, storagePath: String): Future[Either[String, Memory]] = Future {
     try {
       val envProvider = new servers.Abci.EnvironmentProvider(DB(storagePath, None))
       val env = envProvider.transactionEnvironment(TransactionId.forEncodedTransaction(program))

--- a/cli/src/main/scala/pravda/cli/programs/Broadcast.scala
+++ b/cli/src/main/scala/pravda/cli/programs/Broadcast.scala
@@ -1,0 +1,72 @@
+package pravda.cli.programs
+
+import cats._
+import cats.data.EitherT
+import cats.implicits._
+import com.google.protobuf.ByteString
+import pravda.cli.Config
+import pravda.cli.languages.{NodeApiLanguage, CompilersLanguage, IoLanguage}
+import pravda.common.bytes
+import tethys.JsonReader
+import tethys.derivation.semiauto.jsonReader
+import pravda.node.data.serialization._
+import pravda.node.data.serialization.json._
+
+import scala.language.higherKinds
+
+final class Broadcast[F[_]: Monad](io: IoLanguage[F], api: NodeApiLanguage[F], compilers: CompilersLanguage[F]) {
+
+  import Broadcast._
+
+  import Config.Broadcast.Mode
+
+  def apply(config: Config.Broadcast): F[Unit] = {
+
+    val readFromFile = (path: String) =>
+      io.readFromFile(path)
+        .map(_.toRight(s"`$path` is not found."))
+
+    val errorOrResult: EitherT[F, String, String] =
+      for {
+        input <- useOption(config.input)(io.readFromStdin(), readFromFile)
+        walletJson <- useOption(config.input)(io.readFromStdin(), readFromFile)
+        wallet = transcode(Json @@ walletJson.toStringUtf8).to[Wallet]
+        program <- EitherT[F, String, ByteString] {
+          config.mode match {
+            case Mode.Run =>
+              Monad[F].pure(Right(input))
+            case Mode.Deploy =>
+              compilers.forth(s"$$x${bytes.byteString2hex(input)} pcreate")
+            case Mode.Update(Some(address)) if bytes.isHex(address) && address.length == 48 =>
+              compilers.forth(s"$$x${bytes.byteString2hex(input)} $$x$address pupdate")
+            case Mode.Update(Some(_)) =>
+              Monad[F].pure(Left("Invalid program address"))
+            case Mode.Update(None) =>
+              Monad[F].pure(Left("Program address should be defined"))
+            case _ =>
+              Monad[F].pure(Left("Broadcast mode should be selected."))
+          }
+        }
+        result <- EitherT {
+          api.singAndBroadcastTransaction(
+            uriPrefix = config.endpoint,
+            address = wallet.address,
+            privateKey = wallet.privateKey,
+            data = program
+          )
+        }
+      } yield result
+
+    errorOrResult.value.flatMap {
+      case Left(error)   => io.writeStringToStderrAndExit(s"$error\n")
+      case Right(result) => io.writeStringToStdout(result)
+    }
+  }
+}
+
+object Broadcast {
+
+  final case class Wallet(address: ByteString, privateKey: ByteString)
+
+  implicit val walletReader: JsonReader[Wallet] = jsonReader[Wallet]
+}

--- a/cli/src/main/scala/pravda/cli/programs/Compile.scala
+++ b/cli/src/main/scala/pravda/cli/programs/Compile.scala
@@ -5,19 +5,19 @@ import cats.implicits._
 import cats.data.EitherT
 import com.google.protobuf.ByteString
 import pravda.cli.Config
-import pravda.cli.Config.PravdaCompile
+import pravda.cli.Config.CompileMode
 import pravda.cli.languages.{CompilersLanguage, IoLanguage}
 
 import scala.language.higherKinds
 
 class Compile[F[_]: Monad](io: IoLanguage[F], compilers: CompilersLanguage[F]) {
 
-  import PravdaCompile._
+  import CompileMode._
 
   def apply(config: Config.Compile): F[Unit] = {
     val errorOrResult: EitherT[F, String, ByteString] =
       for {
-        input <- usePath(config.input)(
+        input <- useOption(config.input)(
           io.readFromStdin(),
           path => io.readFromFile(path).map(_.toRight(s"`$path` is not found."))
         )

--- a/cli/src/main/scala/pravda/cli/programs/RunBytecode.scala
+++ b/cli/src/main/scala/pravda/cli/programs/RunBytecode.scala
@@ -23,8 +23,8 @@ class RunBytecode[F[_]: Monad](io: IoLanguage[F], vm: VmLanguage[F]) {
       for {
         storagePath <- EitherT.liftF(config.storage.fold(io.createTmpDir())(path => Monad[F].pure(path)))
         executor = bytes.hex2byteString(config.executor)
-        program <- usePath(config.input)(io.readFromStdin(),
-                                         path => io.readFromFile(path).map(_.toRight(s"`$path` is not found.\n")))
+        program <- useOption(config.input)(io.readFromStdin(),
+                                           path => io.readFromFile(path).map(_.toRight(s"`$path` is not found.\n")))
         memory <- EitherT(vm.run(program, executor, storagePath))
       } yield {
         memory

--- a/cli/src/main/scala/pravda/cli/programs/package.scala
+++ b/cli/src/main/scala/pravda/cli/programs/package.scala
@@ -8,10 +8,10 @@ import scala.language.higherKinds
 
 package object programs {
 
-  def usePath[F[_]: Monad, T](
-      maybePath: Option[String])(none: => F[T], some: String => F[Either[String, T]]): EitherT[F, String, T] = {
-    EitherT[F, String, T] {
-      maybePath.fold[F[Either[String, T]]](none.map(Right.apply))(some)
+  def useOption[F[_]: Monad, A, B](maybe: Option[A])(none: => F[B],
+                                                     some: A => F[Either[String, B]]): EitherT[F, String, B] = {
+    EitherT[F, String, B] {
+      maybe.fold[F[Either[String, B]]](none.map(Right.apply))(some)
     }
   }
 }

--- a/cli/src/test/scala/pravda/cli/ParserSuite.scala
+++ b/cli/src/test/scala/pravda/cli/ParserSuite.scala
@@ -65,9 +65,9 @@ object ParserSuite extends TestSuite {
           }
       }
       "*" - assert {
-        import PravdaCompile._
+        import CompileMode._
 
-        def compile(name: String, compiler: PravdaCompile) = {
+        def compile(name: String, compiler: CompileMode) = {
           Parser
             .parse(Seq("compile", name), Config.Nope)
             .exists {

--- a/cli/src/test/scala/pravda/cli/languages/NodeApiLanguageStub.scala
+++ b/cli/src/test/scala/pravda/cli/languages/NodeApiLanguageStub.scala
@@ -1,0 +1,8 @@
+package pravda.cli.languages
+
+import cats.Id
+import com.google.protobuf.ByteString
+
+class NodeApiLanguageStub(result: Either[String, String]) extends NodeApiLanguage[Id] {
+  def singAndBroadcastTransaction(uriPrefix: String, address: ByteString, privateKey: ByteString, data: ByteString): Id[Either[String, String]] = result
+}

--- a/cli/src/test/scala/pravda/cli/programs/BroadcastSuite.scala
+++ b/cli/src/test/scala/pravda/cli/programs/BroadcastSuite.scala
@@ -1,0 +1,48 @@
+package pravda.cli.programs
+
+import cats.Id
+import com.google.protobuf.ByteString
+import pravda.cli.Config
+import pravda.cli.languages.{CompilersLanguage, IoLanguageStub, NodeApiLanguageStub}
+import utest._
+
+import scala.collection.mutable
+
+object BroadcastSuite extends TestSuite {
+
+  final val Wallet = ByteString.copyFromUtf8(
+    """{
+      |  "address":"ed0fdb5d8aa0672a04737f4a017fdafac47b9607a47e553c792681358f0a1d54",
+      |  "privateKey":"e5dda154fae3407b24d2b8a6457a449809234f18a812f95844db25af519f9073ed0fdb5d8aa0672a04737f4a017fdafac47b9607a47e553c792681358f0a1d54"
+      |}
+      """.stripMargin)
+
+  val tests = Tests {
+    "run -w w.json" - {
+      val api = new NodeApiLanguageStub(Right("[]"))
+      val io = new IoLanguageStub(files = mutable.Map("w.json" -> Wallet))
+      val compilers = new CompilersLanguage[Id] {
+        def asm(source: String): Id[Either[String, ByteString]] = Left("nope")
+        def disasm(source: ByteString): Id[String] = ""
+        def forth(source: String): Id[Either[String, ByteString]] = Left("nope")
+      }
+      val program = new Broadcast(io, api, compilers)
+      program(Config.Broadcast(mode = Config.Broadcast.Mode.Run, wallet = Some("w.json")))
+      assert(io.stdout.headOption.contains(ByteString.copyFromUtf8("[]\n")))
+    }
+
+    "run" - {
+      val api = new NodeApiLanguageStub(Right("[]"))
+      val io = new IoLanguageStub()
+      val compilers = new CompilersLanguage[Id] {
+        def asm(source: String): Id[Either[String, ByteString]] = Left("nope")
+        def disasm(source: ByteString): Id[String] = ""
+        def forth(source: String): Id[Either[String, ByteString]] = Left("nope")
+      }
+      val program = new Broadcast(io, api, compilers)
+      program(Config.Broadcast(mode = Config.Broadcast.Mode.Run))
+      assert(io.stderr.headOption.contains(ByteString.copyFromUtf8("Wallet file should be defined\n")))
+    }
+
+  }
+}

--- a/cli/src/test/scala/pravda/cli/programs/CompileSuite.scala
+++ b/cli/src/test/scala/pravda/cli/programs/CompileSuite.scala
@@ -3,13 +3,13 @@ package pravda.cli.programs
 import cats.Id
 import com.google.protobuf.ByteString
 import pravda.cli.Config
-import pravda.cli.Config.PravdaCompile
+import pravda.cli.Config.CompileMode
 import pravda.cli.languages.{CompilersLanguage, IoLanguageStub}
 import utest._
 
 object CompileSuite extends TestSuite {
 
-  import PravdaCompile._
+  import CompileMode._
 
   final val UnexpectedBinaryOutput = ByteString.EMPTY
   final val UnexpectedStringOutput = ""

--- a/node/src/main/scala/pravda/node/clients/AbciClient.scala
+++ b/node/src/main/scala/pravda/node/clients/AbciClient.scala
@@ -36,23 +36,29 @@ class AbciClient(port: Int)(implicit
 //      throw new RuntimeException(s"${prefix} error: ${res.code}:${res.log}")
 //  }
 
-  private def handleResponse(response: HttpResponse, mode: String): Future[List[PbByteString]] = {
+  type ErrorOrStack = Either[RpcError, List[PbByteString]]
+
+  private def handleResponse(response: HttpResponse, mode: String): Future[ErrorOrStack] = {
     response match {
       case HttpResponse(StatusCodes.OK, _, entity, _) =>
         entity.dataBytes.runFold(ByteString.empty)(_ ++ _).map { body =>
           val json = body.utf8String
           mode match {
             case "commit" =>
-              transcode(Json @@ json)
-                .to[RpcCommitResponse]
-                .result
-                .deliver_tx
-                .log
-                .split(',')
-                .toList
-                .map(s => PbByteString.copyFrom(Base64.getDecoder.decode(s)))
+              val response = transcode(Json @@ json).to[RpcCommitResponse]
+              response.result
+                .map { result =>
+                  Right(
+                    result.deliver_tx.log
+                      .split(',')
+                      .toList
+                      .map(s => PbByteString.copyFrom(Base64.getDecoder.decode(s)))
+                  )
+                }
+                .orElse(response.error.map(Left.apply))
+                .getOrElse(Left(UnknownError))
             case _ =>
-              Nil
+              Left(UnknownError)
           }
         }
       case HttpResponse(code, _, _, _) =>
@@ -85,7 +91,7 @@ class AbciClient(port: Int)(implicit
       }
   }
 
-  def broadcastBytes(bytes: Array[Byte], mode: String = "commit"): Future[List[PbByteString]] = {
+  def broadcastBytes(bytes: Array[Byte], mode: String = "commit"): Future[ErrorOrStack] = {
 
     val uri = Uri(s"http://127.0.0.1:$port/broadcast_tx_$mode")
       .withQuery(Uri.Query("tx" -> ("0x" + bytes2hex(bytes))))
@@ -95,7 +101,7 @@ class AbciClient(port: Int)(implicit
       .flatMap(handleResponse(_, mode))
   }
 
-  def broadcastTransaction(tx: SignedTransaction, mode: String = "commit"): Future[List[PbByteString]] = {
+  def broadcastTransaction(tx: SignedTransaction, mode: String = "commit"): Future[ErrorOrStack] = {
 
     val bytes = transcode(tx).to[Bson]
     broadcastBytes(bytes, mode)
@@ -105,7 +111,7 @@ class AbciClient(port: Int)(implicit
                                   privateKey: PrivateKey,
                                   data: TransactionData,
                                   fee: Mytc,
-                                  mode: String = "commit"): Future[List[PbByteString]] = {
+                                  mode: String = "commit"): Future[ErrorOrStack] = {
 
     val unsignedTx = Transaction.UnsignedTransaction(from, data, fee, Random.nextInt())
     val tx = cryptography.signTransaction(privateKey, unsignedTx)
@@ -116,6 +122,8 @@ class AbciClient(port: Int)(implicit
 
 object AbciClient {
 
+  final val UnknownError = RpcError(-1, "", "")
+
   final case class RpcException(error: RpcError) extends Exception(s"${error.message}: ${error.data}")
   final case class RpcHttpException(httpCode: Int)
       extends Exception(s"RPC request to Tendermint failed with HTTP code $httpCode")
@@ -124,7 +132,7 @@ object AbciClient {
   final case class RpcSyncResponse(jsonrpc: String, id: String, result: TxSyncResult)
   final case class RpcAsyncResponse(jsonrpc: String, id: String, result: TxResult)
 
-  final case class RpcCommitResponse(result: TxCommitResult)
+  final case class RpcCommitResponse(result: Option[TxCommitResult], error: Option[RpcError])
   final case class TxCommitResult(check_tx: TxResult, deliver_tx: TxResult)
   final case class TxResult(log: String)
 

--- a/node/src/main/scala/pravda/node/data/blockchain.scala
+++ b/node/src/main/scala/pravda/node/data/blockchain.scala
@@ -1,5 +1,6 @@
 package pravda.node.data
 
+import cats.Show
 import com.google.protobuf.ByteString
 import common._
 import supertagged.TaggedType
@@ -27,6 +28,17 @@ object blockchain {
                                        fee: Mytc,
                                        nonce: Int)
         extends Transaction
+
+    import pravda.common.bytes
+
+    object SignedTransaction {
+      implicit val showInstance: Show[SignedTransaction] = { t =>
+        val from = bytes.byteString2hex(t.from)
+        val program = bytes.byteString2hex(t.program)
+        val signature = bytes.byteString2hex(t.signature)
+        s"transaction.signed[from=$from,program=$program,signature=$signature,nonce=${t.nonce},fee=${t.fee}]"
+      }
+    }
 
     final case class AuthorizedTransaction(from: Address,
                                            program: TransactionData,

--- a/node/src/main/scala/pravda/node/data/serialization/json.scala
+++ b/node/src/main/scala/pravda/node/data/serialization/json.scala
@@ -194,41 +194,26 @@ object json {
   implicit val txResultReader: JsonReader[TxResult] =
     jsonReader[TxResult]
 
-  implicit val txResultWriter: JsonWriter[TxResult] =
-    jsonWriter[TxResult]
-
   implicit val txSyncResultReader: JsonReader[TxSyncResult] =
     jsonReader[TxSyncResult]
-
-  implicit val txSyncResultWriter: JsonWriter[TxSyncResult] =
-    jsonWriter[TxSyncResult]
 
   implicit val txCommitResultReader: JsonReader[TxCommitResult] =
     jsonReader[TxCommitResult]
 
-  implicit val txCommitResultWriter: JsonWriter[TxCommitResult] =
-    jsonWriter[TxCommitResult]
-
   implicit val rpcSyncResponseReader: JsonReader[RpcSyncResponse] =
     jsonReader[RpcSyncResponse]
-
-  implicit val rpcSyncResponseWriter: JsonWriter[RpcSyncResponse] =
-    jsonWriter[RpcSyncResponse]
 
   implicit val rpcAsyncResponseReader: JsonReader[RpcAsyncResponse] =
     jsonReader[RpcAsyncResponse]
 
-  implicit val rpcAsyncResponseWriter: JsonWriter[RpcAsyncResponse] =
-    jsonWriter[RpcAsyncResponse]
-
   implicit val rpcCommitResponseReader: JsonReader[RpcCommitResponse] =
     jsonReader[RpcCommitResponse]
 
-  implicit val rpcCommitResponseWriter: JsonWriter[RpcCommitResponse] =
-    jsonWriter[RpcCommitResponse]
-
-  implicit val rpcError: JsonReader[RpcError] =
+  implicit val rpcErrorReader: JsonReader[RpcError] =
     jsonReader[RpcError]
+
+  implicit val rpcErrorWriter: JsonWriter[RpcError] =
+    jsonWriter[RpcError]
 
   implicit val rpcTxResponseReader: JsonReader[RpcTxResponse] =
     jsonReader[RpcTxResponse]

--- a/node/src/main/scala/pravda/node/servers/ApiRoute.scala
+++ b/node/src/main/scala/pravda/node/servers/ApiRoute.scala
@@ -8,11 +8,14 @@ import akka.http.scaladsl.model.{HttpEntity, MediaTypes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.unmarshalling.Unmarshaller
+import cats.Show
 import com.google.protobuf.ByteString
+import pravda.common.bytes
 import pravda.node.clients.AbciClient
 import pravda.node.data.blockchain.Transaction.SignedTransaction
 import pravda.node.data.blockchain.TransactionData
 import pravda.node.data.common.{Address, Mytc}
+import pravda.node.data.serialization.json._
 
 import scala.concurrent.duration._
 import scala.util.Random
@@ -22,10 +25,13 @@ class ApiRoute(abciClient: AbciClient) {
   import pravda.node.utils.AkkaHttpSpecials._
 
   val hexUnmarshaller: Unmarshaller[String, ByteString] =
-    Unmarshaller.strict(hex => ByteString.copyFrom(Base64.getDecoder.decode(hex)))
+    Unmarshaller.strict(hex => bytes.hex2byteString(hex))
 
   val bigDecimalUnmarshaller: Unmarshaller[String, BigDecimal] =
     Unmarshaller.strict(s => BigDecimal(s))
+
+  val intUnmarshaller: Unmarshaller[String, Int] =
+    Unmarshaller.strict(s => s.toInt)
 
   def bodyToTransactionData(body: HttpEntity.Strict): TransactionData = {
     body.contentType.mediaType match {
@@ -42,38 +48,26 @@ class ApiRoute(abciClient: AbciClient) {
   val route: Route =
     pathPrefix("public") {
       post {
-        path("broadcast") {
-
-          parameters(
-            ('from.as(hexUnmarshaller), 'signature.as(hexUnmarshaller), 'fee.as(bigDecimalUnmarshaller), 'mode.?)) {
-            (from, signature, fee, maybeMode) =>
+        withoutRequestTimeout {
+          path("broadcast") {
+            parameters(
+              ('from.as(hexUnmarshaller),
+               'signature.as(hexUnmarshaller),
+               'nonce.as(intUnmarshaller).?,
+               'fee.as(bigDecimalUnmarshaller),
+               'mode.?)) { (from, signature, maybeNonce, fee, maybeMode) =>
               extractStrictEntity(1.second) { body =>
                 val program = bodyToTransactionData(body)
-                val tx = SignedTransaction(Address @@ from, program, signature, Mytc @@ fee, Random.nextInt)
+                val nonce = maybeNonce.getOrElse(Random.nextInt())
+                val tx = SignedTransaction(Address @@ from, program, signature, Mytc @@ fee, nonce)
+                println(Show[SignedTransaction].show(tx))
                 val mode = maybeMode.getOrElse("commit")
                 val result = abciClient.broadcastTransaction(tx, mode)
 
-                onSuccess(result) { stack =>
-                  complete(utils.showStack(stack))
+                onSuccess(result) {
+                  case Right(stack) => complete(stack)
+                  case Left(error)  => complete(error)
                 }
-              }
-          }
-        }
-      }
-    } ~ pathPrefix("private") {
-      val paymentWallet = Config.timeChainConfig.paymentWallet
-      post {
-        path("broadcast") {
-
-          parameters(('fee.as(bigDecimalUnmarshaller), 'mode.?)) { (fee, maybeMode) =>
-            extractStrictEntity(1.second) { body =>
-              val program = bodyToTransactionData(body)
-              val from = paymentWallet.address
-              val mode = maybeMode.getOrElse("commit")
-              val result =
-                abciClient.singAndBroadcastTransaction(from, paymentWallet.privateKey, program, Mytc @@ fee, mode)
-              onSuccess(result) { stack =>
-                complete(utils.showStack(stack))
               }
             }
           }

--- a/node/src/main/scala/pravda/node/servers/GuiRoute.scala
+++ b/node/src/main/scala/pravda/node/servers/GuiRoute.scala
@@ -278,7 +278,7 @@ class GuiRoute(abciClient: AbciClient, db: DB)(implicit system: ActorSystem, mat
                             _ <- access.transition { _ =>
                               SendTransactionScreen(
                                 inProgress = false,
-                                maybeResult = Some(utils.showStack(stack))
+                                maybeResult = Some(stack.map(utils.showStack).toString)
                               )
                             }
                           } yield {
@@ -324,7 +324,7 @@ class GuiRoute(abciClient: AbciClient, db: DB)(implicit system: ActorSystem, mat
                             _ <- access.transition { _ =>
                               SendTransactionScreen(
                                 inProgress = false,
-                                maybeResult = Some(utils.showStack(stack))
+                                maybeResult = Some(stack.map(utils.showStack).toString)
                               )
                             }
                           } yield {

--- a/node/src/main/scala/pravda/node/utils/package.scala
+++ b/node/src/main/scala/pravda/node/utils/package.scala
@@ -10,7 +10,7 @@ package object utils {
 
   def showStack(stack: Seq[ByteString]): String =
     stack
-      .map(bs => byteString2hex(bs))
+      .map(bs => '"' + byteString2hex(bs) + '"')
       .mkString("[", ", ", "]")
 
   def detectCpuArchitecture(): Future[CpuArchitecture] = Future.successful {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.10")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")


### PR DESCRIPTION
1. New `broadcast` command with `deploy`, `update`, `run` subcommands.
2. Languages moved to `Future` from `Id` because `NodeApiLanguageImpl` works asynchronously and  needs `akka-http`.
3. Scalafix and scalafmt checks now runs before compilation on CI. It's speed up checks when developer just forget to make scalafmt or scalafix before commit.
4. `/api/public/broadcast` now returns valid JSON with corresponding Content-Type.