### PR TITLE
Close #67: Remove fixme

### DIFF
--- a/node/src/main/scala/pravda/node/servers/Abci.scala
+++ b/node/src/main/scala/pravda/node/servers/Abci.scala
@@ -35,7 +35,6 @@ class Abci(applicationStateDb: DB, abciClient: AbciClient)(implicit ec: Executio
 
   var proposedHeight = 0L
   val consensusEnv = new EnvironmentProvider(applicationStateDb)
-  // FIXME fomkin: mempool should work without data base
   val mempoolEnv = new EnvironmentProvider(applicationStateDb)
 
   def info(request: RequestInfo): Future[ResponseInfo] = {


### PR DESCRIPTION
It seems like mempool can not work without the database, because it needs to read program data.