### PR TITLE
Close #86: Return back scala-abci-server publishLocal.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,13 +6,15 @@ workspace:
   path: code
 pipeline:
   tests:
-    image: gcr.io/time-coin/builder-java-sbt:0.1
+    image: gcr.io/time-coin/sbt:latest
     volumes:
       - /var/lib/sbt-cache:/workdir/sbt
       - /var/lib/ivy-cache:/workdir/ivy
     commands:
       - export SBT_OPTS='-Dsbt.global.base=/workdir/sbt/ -Dsbt.ivy.home=/workdir/ivy/ -Divy.home=/workdir/ivy/'
-      - cd /workdir/code && sbt $SBT_OPTS -mem 2048 test scalafmtCheck scalafixTest
+      - git clone https://github.com/mytimecoin/scala-abci-server.git scala-abci-server --depth 1
+      - cd /workdir/code/scala-abci-server && sbt $SBT_OPTS publishLocal
+      - cd /workdir/code && sbt $SBT_OPTS -mem 2048 scalafmtCheck scalafixTest test
   package:
     image: gcr.io/time-coin/sbt:latest
     volumes:


### PR DESCRIPTION
It was wrong decision to latently keep dependency in the agent host
cache. Explicitly publishLocal scala-abci-server until we publish it to
some public repo.