### PR TITLE
Close #105: Make DroneCI fetch tags.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,7 @@
 clone:
-  clone-nothing:
+  clone:
     image: plugins/git
+    tags: true
 workspace:
   base: /workdir
   path: code


### PR DESCRIPTION
Drone by default doesn't fetch tags.
We moved to sbt-git for versioning, so we need them now.